### PR TITLE
fix(module): set required DMS sell trust flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ resource "alicloud_rds_account" "account" {
 
 resource "alicloud_dms_enterprise_instance" "default" {
   dba_uid           = var.dms_dba_uid
+  sell_trust        = false
   host              = alicloud_db_instance.instance.connection_string
   port              = 3306
   network_type      = "VPC"


### PR DESCRIPTION
## Summary
- set the required `sell_trust` argument on `alicloud_dms_enterprise_instance`
- keep the existing module inputs and example interface unchanged

## Validation
- terraform fmt -check -recursive
- git diff --check
- terraform init -backend=false
- terraform validate (warnings only)